### PR TITLE
Hide comment vote information if running CMS

### DIFF
--- a/lib/components/ThingComment.js
+++ b/lib/components/ThingComment.js
@@ -129,14 +129,7 @@ const ThingComment = ({
               </a>]{" "}
             </span>
           )}
-          {score_hidden ? (
-            <span
-              className="score-hidden"
-              title="scores are currently hidden for this comment"
-            >
-						[score hidden]
-            </span>
-          ) : (
+          {!score_hidden && (
             [
               <span className="score dislikes" key="dislikes">
                 {downs} points


### PR DESCRIPTION
Add `isCMS` to `ThingComment` to tailor specific messages if running cms on pgui.